### PR TITLE
fix margin-top of .site-header to not obscure content when not logged in

### DIFF
--- a/src/scss/components/biomes/_layout--global.scss
+++ b/src/scss/components/biomes/_layout--global.scss
@@ -1,25 +1,16 @@
 .site-header {
-	margin: 4rem 1.25rem 0;
+	margin: 6rem 1.25rem 0;
 	@media (min-width: get-breakpoint(sm)) {
-		margin: 4rem 2.25rem 0;
+		margin: 6rem 2.25rem 0;
 	}
 	@media (min-width: get-breakpoint(md)) {
-		margin: 4rem 4.25rem 0;
+		margin: 6rem 4.25rem 0;
 	}
 }
 
 .admin-bar {
 	#wpadminbar {
 		position: fixed;
-	}
-	.site-header {
-		margin: 6rem 1.25rem 0;
-		@media (min-width: get-breakpoint(sm)) {
-			margin: 6rem 2.25rem 0;
-		}
-		@media (min-width: get-breakpoint(md)) {
-			margin: 6rem 4.25rem 0;
-		}
 	}
 }
 


### PR DESCRIPTION
Checked across all pages with content I could think of (including homepage where breadcrumbs are not present) when not logged in as well as logged in and looks good