### PR TITLE
Pea/theme.json updates

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -3,6 +3,8 @@
 	"settings": {
 		"color": {
             "custom": false,
+			"defaultGradients": false,
+			"defaultPalette": false,
             "customDuotone": false,
             "customGradient": false,
             "link": false,

--- a/theme.json
+++ b/theme.json
@@ -99,6 +99,11 @@
 		"typography": {
 			"customFontSize": false,
 			"customLineHeight": false,
+			"fontStyle": false, 
+			"fontWeight": false, 
+			"letterSpacing": false, 
+			"textDecoration": false, 
+			"textTransform": false,
 			"dropCap": false,
 			"fontFamilies": [
 				{


### PR DESCRIPTION
@thiagodemellobueno 

Updated some settings in `theme.json` to disable new settings introduced in 5.9.

See: https://make.wordpress.org/core/2022/01/08/updates-for-settings-styles-and-theme-json/