### PR TITLE
Bugfix - Use default WP timezone if no timezone is provided

### DIFF
--- a/template-parts/content-an_event.php
+++ b/template-parts/content-an_event.php
@@ -12,7 +12,7 @@ $taxonomy = 'event_tag';
 $date_format          = \has_term( array( 'welcome-call', 'welcome-calls' ), $taxonomy, $post_id ) ? 'D, M j' : 'l F j, Y';
 $time_format          = 'g:ia';
 $default_timezone     = \get_option( 'timezone_string' );
-$timezone             = \get_post_meta( $post_id, 'timezone', true ) ?? $default_timezone;
+$timezone             = ( $tm = \get_post_meta( $post_id, 'timezone', true ) ) ? $tm : $default_timezone;
 $raw_start_date       = \get_post_meta( $post_id, 'start_date', true );
 $raw_end_date         = \get_post_meta( $post_id, 'end_date', true );
 $start_datetime       = new \DateTime( $raw_start_date );


### PR DESCRIPTION
ref: https://app.asana.com/0/1199911848001626/1201903244097532/f