### PR TITLE
fix media links with custom titles for shorter titles

### DIFF
--- a/src/scss/components/molecules/_media-links.scss
+++ b/src/scss/components/molecules/_media-links.scss
@@ -32,11 +32,15 @@
 }
 
 .media-link-custom-title {
-	.wp-block-zwt-beautiful-link-preview:first-of-type {
+	border-bottom: 0.25rem solid #1e9981;
+	margin-bottom: 2rem;
+	.wp-block-zwt-beautiful-link-preview {
 		border: none;
 		margin-bottom: 0;
-		.zwt-wp-link-prev-texts {
-			display: none;
+		&:first-of-type {
+			.zwt-wp-link-prev-texts {
+				display: none;
+			}
 		}
 	}
 	.custom-title {


### PR DESCRIPTION
@thiagodemellobueno I made some tweaks to the Media Link Custom Title scss to handle media items with shorter titles. Not super urgent to get merged or anything but will be useful next time this block is used - tested it with titles of every size and is looking good. 