### PR TITLE
Adds RSVP form template and related functions

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -139,19 +139,18 @@ function get_event_recurrences( $recurrence_id, $args = array() ) {
  * @param obj $EM_Event
  * @return mixed false || string
  */
-function get_event_location_type( $EM_Event ) {
+function get_event_type( object $EM_Event ) {
 	if ( ! class_exists( '\EM_Events' ) ) {
 		return;
 	}
 
-	$location = false;
-	if( $EM_Event->has_location() ) {
-		$location = 'physical';
-	}
+	$type = 'physical';
 	if( $EM_Event->has_event_location() ) {
-		$location = 'virtual';
+		$type = $EM_Event->event_location_type;
 	}
-	return $location;
+	return $type;
+}
+
 /**
  * Check if zoom event
  *

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -152,6 +152,16 @@ function get_event_location_type( $EM_Event ) {
 		$location = 'virtual';
 	}
 	return $location;
+/**
+ * Check if zoom event
+ *
+ * @param object $EM_Event
+ * @return boolean
+ */
+function is_zoom( object $EM_Event ) : bool {
+	$type = get_event_type( $EM_Event );
+	return str_contains( $type, 'zoom' );
+}
 }
 
 /**

--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -161,6 +161,15 @@ function is_zoom( object $EM_Event ) : bool {
 	$type = get_event_type( $EM_Event );
 	return str_contains( $type, 'zoom' );
 }
+
+/**
+ * Has RSVP
+ *
+ * @param integer $id
+ * @return boolean
+ */
+function has_rsvp( int $post_id ) {
+	return \get_post_meta( $post_id, 'enable_rsvp', true );
 }
 
 /**

--- a/template-parts/components/form-event-rsvp.php
+++ b/template-parts/components/form-event-rsvp.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Template part for displaying an event RSVP form.
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package DebtCollective
+ */
+$options = get_option( 'dc_events_manager_options' );
+if( ! isset( $options['rsvp_form'] ) || ! $options['rsvp_form'] ) {
+	return;
+}
+$EM_Event = $args['EM_Event'];
+
+/**
+ * Contact Form 7 form
+ * Modify fields and markup within plugin
+ * 
+ * `data-status` changes to 'sent' after form is submitted
+ * 'sent' class is added to form after form is submitted
+ */
+$form = sprintf( '[contact-form-7 id="%s" title="%s" event_id="%s" post_id="%s" zoom_id=""]', 
+	$options['rsvp_form'],
+	esc_html__( 'RSVP', 'debtcollective' ),
+	$EM_Event->event_id,
+	$args['post_id'],
+	( DebtCollective\Inc\is_zoom( $EM_Event ) ) ? $EM_Event->event_location->data['id'] : null
+);
+?>
+
+<div class="event__rsvp-form">
+	<header class="event__rsvp-form-header">
+		<h3 class="event__rsvp-form-title"><?php esc_html_e( 'RSVP', 'debtcollective' ); ?></h3>
+	</header>
+	<?php
+	echo do_shortcode( $form );
+	?>
+</div>

--- a/template-parts/components/person.php
+++ b/template-parts/components/person.php
@@ -4,7 +4,7 @@
  *
  * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
  *
- * @package site-functionality
+ * @package DebtCollective
  */
 $attributes = $data->attributes;
 $user = $data->person;

--- a/template-parts/content-event.php
+++ b/template-parts/content-event.php
@@ -73,7 +73,19 @@ $class       .= $is_recurring ? ' is-recurring' : '';
 	<footer class="event__footer">
 		<?php debtcollective_event_recurrences_placeholders( $EM_Event ); ?>
 
-		<?php debtcollective_rsvp_placeholders( $EM_Event ); ?>
+		<?php
+		if ( DebtCollective\Inc\has_rsvp( $post_id ) ) {
+			get_template_part(
+				'template-parts/components/form-event',
+				'rsvp',
+				array(
+					'EM_Event' => $EM_Event,
+					'post_id'  => $post_id,
+				)
+			);
+		}
+		?>
+
 	</footer>
 
 </article><!-- #post-## -->


### PR DESCRIPTION
- [Add RSVP form template](https://github.com/debtcollective/dotorg-theme/commit/fb3121b72102c480956df10100449d0031371fb6)
- [Load RSVP form template if RSVP enabled for event](https://github.com/debtcollective/dotorg-theme/commit/c25a88c20607d5fec37b6527117a8925ef24a32c)
- [Fix comments](https://github.com/debtcollective/dotorg-theme/commit/652b516bda0975ba213293e4adef18c460596109)
- [Add helper to check if zoom event](https://github.com/debtcollective/dotorg-theme/commit/26933b8c3d8f56d3e246a7958ac57b423381768b)
- [Determine event type](https://github.com/debtcollective/dotorg-theme/commit/2389c6f3b9d432f47a3d2477eac4e3cfa8505fa9)
  -  Will return 'physical' no `event_location` is present
  - Otherwise, will return the event location type, currently
     - `zoom_room`
     - `zoom_webinar`
     - `zoom_meeting`
     - `ur`l
- [Add helper to determine if rsvp enabled](https://github.com/debtcollective/dotorg-theme/commit/1ef1819cecefbda6411d8aaf8a2dfd1a16c043fc)