### PR TITLE
Bugfix

### DIFF
--- a/page-templates/events-page.php
+++ b/page-templates/events-page.php
@@ -30,7 +30,7 @@ $sort        = ( $sort = get_post_meta( get_the_ID(), 'event_sort_upcoming', tru
 
 		<?php
 		apply_filters( 'em_content_events_args', 'DebtCollective\Inc\add_event_args' );
-		em_content();
+		the_content();
 
 		if ( ! $has_sidebar ) :
 


### PR DESCRIPTION
Fatal error: Uncaught ArgumentCountError: Too few arguments to function em_content(), 0 passed in /var/www/html/wp-content/themes/debtcollective/page-templates/events-page.php on line 33 and exactly 1 expected in /var/www/html/wp-content/plugins/events-manager/em-events.php:11